### PR TITLE
add nonce and fee params

### DIFF
--- a/services/construction_service.go
+++ b/services/construction_service.go
@@ -239,6 +239,7 @@ func (s *ConstructionAPIService) ConstructionMetadata(ctx context.Context, reque
 			return nil, ErrFeeTooLow
 		}
 		txn.TxnFeeNanos = options.TxnFeeNanos
+		fee = options.TxnFeeNanos
 	}
 
 	desoTxnBytes, err := txn.ToBytes(true)

--- a/services/construction_service.go
+++ b/services/construction_service.go
@@ -164,6 +164,10 @@ func (s *ConstructionAPIService) ConstructionMetadata(ctx context.Context, reque
 		return nil, wrapErr(ErrUnableToParseIntermediateResult, err)
 	}
 
+	if options.LegacyUTXOSelection && s.node.GetBlockchain().BlockTip().Height >= s.node.Params.ForkHeights.BalanceModelBlockHeight {
+		return nil, ErrLegacyUtxoSelectionNotAllowed
+	}
+
 	// Determine the network-wide feePerKB rate
 	feePerKB := mempoolView.GlobalParamsEntry.MinimumNetworkFeeNanosPerKB
 	if feePerKB == 0 {

--- a/services/construction_service.go
+++ b/services/construction_service.go
@@ -102,23 +102,23 @@ func (s *ConstructionAPIService) ConstructionPreprocess(ctx context.Context, req
 
 	var err error
 	// Parse nonce and fee fields from the metadata
-	optionsObj.NoncePartialID, err = CheckMetadataForAttributeAndParseUint64(request.Metadata, "nonce_partial_id"))
+	optionsObj.NoncePartialID, err = CheckMetadataForAttributeAndParseUint64(request.Metadata, "nonce_partial_id")
 	if err != nil {
 		return nil, wrapErr(ErrUnableToParseIntermediateResult, err)
 	}
-	optionsObj.NonceExpirationBlockHeight, err = CheckMetadataForAttributeAndParseUint64(request.Metadata, "nonce_expiration_block_height"))
+	optionsObj.NonceExpirationBlockHeight, err = CheckMetadataForAttributeAndParseUint64(request.Metadata, "nonce_expiration_block_height")
 	if err != nil {
 		return nil, wrapErr(ErrUnableToParseIntermediateResult, err)
 	}
-	optionsObj.NonceExpirationBlockHeightOffset, err = CheckMetadataForAttributeAndParseUint64(request.Metadata, "nonce_expiration_block_height_offset"))
+	optionsObj.NonceExpirationBlockHeightOffset, err = CheckMetadataForAttributeAndParseUint64(request.Metadata, "nonce_expiration_block_height_offset")
 	if err != nil {
 		return nil, wrapErr(ErrUnableToParseIntermediateResult, err)
 	}
-	optionsObj.FeeRateNanosPerKB, err = CheckMetadataForAttributeAndParseUint64(request.Metadata, "fee_rate_nanos_per_kb"))
+	optionsObj.FeeRateNanosPerKB, err = CheckMetadataForAttributeAndParseUint64(request.Metadata, "fee_rate_nanos_per_kb")
 	if err != nil {
 		return nil, wrapErr(ErrUnableToParseIntermediateResult, err)
 	}
-	optionsObj.TxnFeeNanos, err = CheckMetadataForAttributeAndParseUint64(request.Metadata, "txn_fee_nanos"))
+	optionsObj.TxnFeeNanos, err = CheckMetadataForAttributeAndParseUint64(request.Metadata, "txn_fee_nanos")
 	if err != nil {
 		return nil, wrapErr(ErrUnableToParseIntermediateResult, err)
 	}

--- a/services/construction_service.go
+++ b/services/construction_service.go
@@ -102,55 +102,25 @@ func (s *ConstructionAPIService) ConstructionPreprocess(ctx context.Context, req
 
 	var err error
 	// Parse nonce and fee fields from the metadata
-	if noncePartialID, exists := request.Metadata["nonce_partial_id"]; exists {
-		noncePartialIDStr, ok := noncePartialID.(string)
-		if !ok {
-			return nil, wrapErr(ErrUnableToParseIntermediateResult, fmt.Errorf("nonce_partial_id is not a string"))
-		}
-		optionsObj.NoncePartialID, err = strconv.ParseUint(noncePartialIDStr, 10, 64)
-		if err != nil {
-			return nil, wrapErr(ErrUnableToParseIntermediateResult, errors.Wrapf(err, "nonce_partial_id: %v", noncePartialIDStr))
-		}
+	optionsObj.NoncePartialID, err = CheckMetadataForAttributeAndParseUint64(request.Metadata, "nonce_partial_id"))
+	if err != nil {
+		return nil, wrapErr(ErrUnableToParseIntermediateResult, err)
 	}
-	if nonceExpirationBlockHeight, exists := request.Metadata["nonce_expiration_block_height"]; exists {
-		nonceExpirationBlockHeightStr, ok := nonceExpirationBlockHeight.(string)
-		if !ok {
-			return nil, wrapErr(ErrUnableToParseIntermediateResult, fmt.Errorf("nonce_expiration_block_height is not a string"))
-		}
-		optionsObj.NonceExpirationBlockHeight, err = strconv.ParseUint(nonceExpirationBlockHeightStr, 10, 64)
-		if err != nil {
-			return nil, wrapErr(ErrUnableToParseIntermediateResult, errors.Wrapf(err, "nonce_expiration_block_height: %v", nonceExpirationBlockHeightStr))
-		}
+	optionsObj.NonceExpirationBlockHeight, err = CheckMetadataForAttributeAndParseUint64(request.Metadata, "nonce_expiration_block_height"))
+	if err != nil {
+		return nil, wrapErr(ErrUnableToParseIntermediateResult, err)
 	}
-	if NonceExpirationBlockHeightOffset, exists := request.Metadata["nonce_expiration_block_height_offset"]; exists {
-		NonceExpirationBlockHeightOffsetStr, ok := NonceExpirationBlockHeightOffset.(string)
-		if !ok {
-			return nil, wrapErr(ErrUnableToParseIntermediateResult, fmt.Errorf("nonce_expiration_block_height_offset is not a string"))
-		}
-		optionsObj.NonceExpirationBlockHeightOffset, err = strconv.ParseUint(NonceExpirationBlockHeightOffsetStr, 10, 64)
-		if err != nil {
-			return nil, wrapErr(ErrUnableToParseIntermediateResult, errors.Wrapf(err, "nonce_expiration_block_height_offset: %v", NonceExpirationBlockHeightOffsetStr))
-		}
+	optionsObj.NonceExpirationBlockHeightOffset, err = CheckMetadataForAttributeAndParseUint64(request.Metadata, "nonce_expiration_block_height_offset"))
+	if err != nil {
+		return nil, wrapErr(ErrUnableToParseIntermediateResult, err)
 	}
-	if feeRateNanosPerKB, exists := request.Metadata["fee_rate_nanos_per_kb"]; exists {
-		feeRateNanosPerKBStr, ok := feeRateNanosPerKB.(string)
-		if !ok {
-			return nil, wrapErr(ErrUnableToParseIntermediateResult, fmt.Errorf("fee_rate_nanos_per_kb is not a string"))
-		}
-		optionsObj.FeeRateNanosPerKB, err = strconv.ParseUint(feeRateNanosPerKBStr, 10, 64)
-		if err != nil {
-			return nil, wrapErr(ErrUnableToParseIntermediateResult, errors.Wrapf(err, "fee_rate_nanos_per_kb: %v", feeRateNanosPerKBStr))
-		}
+	optionsObj.FeeRateNanosPerKB, err = CheckMetadataForAttributeAndParseUint64(request.Metadata, "fee_rate_nanos_per_kb"))
+	if err != nil {
+		return nil, wrapErr(ErrUnableToParseIntermediateResult, err)
 	}
-	if txnFeeNanos, exists := request.Metadata["txn_fee_nanos"]; exists {
-		txnFeeNanosStr, ok := txnFeeNanos.(string)
-		if !ok {
-			return nil, wrapErr(ErrUnableToParseIntermediateResult, fmt.Errorf("txn_fee_nanos is not a string"))
-		}
-		optionsObj.TxnFeeNanos, err = strconv.ParseUint(txnFeeNanosStr, 10, 64)
-		if err != nil {
-			return nil, wrapErr(ErrUnableToParseIntermediateResult, errors.Wrapf(err, "txn_fee_nanos: %v", txnFeeNanosStr))
-		}
+	optionsObj.TxnFeeNanos, err = CheckMetadataForAttributeAndParseUint64(request.Metadata, "txn_fee_nanos"))
+	if err != nil {
+		return nil, wrapErr(ErrUnableToParseIntermediateResult, err)
 	}
 
 	options, err := types.MarshalMap(optionsObj)
@@ -161,6 +131,22 @@ func (s *ConstructionAPIService) ConstructionPreprocess(ctx context.Context, req
 	return &types.ConstructionPreprocessResponse{
 		Options: options,
 	}, nil
+}
+
+func CheckMetadataForAttributeAndParseUint64(metadata map[string]interface{}, key string) (uint64, error) {
+	value, exists := metadata[key]
+	if !exists {
+		return 0, nil
+	}
+	valueStr, ok := value.(string)
+	if !ok {
+		return 0, fmt.Errorf("%s is not a string", key)
+	}
+	parsedValue, err := strconv.ParseUint(valueStr, 10, 64)
+	if err != nil {
+		return 0, errors.Wrapf(err, "%s: %v", key, valueStr)
+	}
+	return parsedValue, nil
 }
 
 func (s *ConstructionAPIService) ConstructionMetadata(ctx context.Context, request *types.ConstructionMetadataRequest) (*types.ConstructionMetadataResponse, *types.Error) {

--- a/services/construction_service.go
+++ b/services/construction_service.go
@@ -99,20 +99,36 @@ func (s *ConstructionAPIService) ConstructionPreprocess(ctx context.Context, req
 		break
 	}
 
+	var err error
 	if noncePartialID, exists := request.Metadata["nonce_partial_id"]; exists {
-		optionsObj.NoncePartialID = noncePartialID.(uint64)
+		optionsObj.NoncePartialID, err = strconv.ParseUint(noncePartialID.(string), 10, 64)
+		if err != nil {
+			return nil, wrapErr(ErrUnableToParseIntermediateResult, err)
+		}
 	}
 	if nonceExpirationBlockHeight, exists := request.Metadata["nonce_expiration_block_height"]; exists {
-		optionsObj.NonceExpirationBlockHeight = nonceExpirationBlockHeight.(uint64)
+		optionsObj.NonceExpirationBlockHeight, err = strconv.ParseUint(nonceExpirationBlockHeight.(string), 10, 64)
+		if err != nil {
+			return nil, wrapErr(ErrUnableToParseIntermediateResult, err)
+		}
 	}
 	if nonceExpirationBlockBuffer, exists := request.Metadata["nonce_expiration_block_buffer"]; exists {
-		optionsObj.NonceExpirationBlockBuffer = nonceExpirationBlockBuffer.(uint64)
+		optionsObj.NonceExpirationBlockBuffer, err = strconv.ParseUint(nonceExpirationBlockBuffer.(string), 10, 64)
+		if err != nil {
+			return nil, wrapErr(ErrUnableToParseIntermediateResult, err)
+		}
 	}
 	if feeRateNanosPerKB, exists := request.Metadata["fee_rate_nanos_per_kb"]; exists {
-		optionsObj.FeeRateNanosPerKB = feeRateNanosPerKB.(uint64)
+		optionsObj.FeeRateNanosPerKB, err = strconv.ParseUint(feeRateNanosPerKB.(string), 10, 64)
+		if err != nil {
+			return nil, wrapErr(ErrUnableToParseIntermediateResult, err)
+		}
 	}
 	if txnFeeNanos, exists := request.Metadata["txn_fee_nanos"]; exists {
-		optionsObj.TxnFeeNanos = txnFeeNanos.(uint64)
+		optionsObj.TxnFeeNanos, err = strconv.ParseUint(txnFeeNanos.(string), 10, 64)
+		if err != nil {
+			return nil, wrapErr(ErrUnableToParseIntermediateResult, err)
+		}
 	}
 
 	options, err := types.MarshalMap(optionsObj)

--- a/services/construction_service.go
+++ b/services/construction_service.go
@@ -214,7 +214,6 @@ func (s *ConstructionAPIService) ConstructionMetadata(ctx context.Context, reque
 	if options.NoncePartialID > 0 {
 		txn.TxnNonce.PartialID = options.NoncePartialID
 	}
-	// TODO: validate that the expiration block height is valid.
 	currentBlockBuffer := uint64(lib.DefaultMaxNonceExpirationBlockHeightOffset)
 	if mempoolView.GlobalParamsEntry.MaxNonceExpirationBlockHeightOffset > 0 {
 		currentBlockBuffer = mempoolView.GlobalParamsEntry.MaxNonceExpirationBlockHeightOffset

--- a/services/construction_service.go
+++ b/services/construction_service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/deso-protocol/core/lib"
 	merkletree "github.com/deso-protocol/go-merkle-tree"
 	"github.com/deso-protocol/rosetta-deso/deso"
+	"github.com/pkg/errors"
 	"math/big"
 	"reflect"
 	"strconv"
@@ -101,33 +102,53 @@ func (s *ConstructionAPIService) ConstructionPreprocess(ctx context.Context, req
 
 	var err error
 	if noncePartialID, exists := request.Metadata["nonce_partial_id"]; exists {
-		optionsObj.NoncePartialID, err = strconv.ParseUint(noncePartialID.(string), 10, 64)
+		noncePartialIDStr, ok := noncePartialID.(string)
+		if !ok {
+			return nil, wrapErr(ErrUnableToParseIntermediateResult, fmt.Errorf("nonce_partial_id is not a string"))
+		}
+		optionsObj.NoncePartialID, err = strconv.ParseUint(noncePartialIDStr, 10, 64)
 		if err != nil {
-			return nil, wrapErr(ErrUnableToParseIntermediateResult, err)
+			return nil, wrapErr(ErrUnableToParseIntermediateResult, errors.Wrapf(err, "nonce_partial_id: %v", noncePartialIDStr))
 		}
 	}
 	if nonceExpirationBlockHeight, exists := request.Metadata["nonce_expiration_block_height"]; exists {
-		optionsObj.NonceExpirationBlockHeight, err = strconv.ParseUint(nonceExpirationBlockHeight.(string), 10, 64)
+		nonceExpirationBlockHeightStr, ok := nonceExpirationBlockHeight.(string)
+		if !ok {
+			return nil, wrapErr(ErrUnableToParseIntermediateResult, fmt.Errorf("nonce_expiration_block_height is not a string"))
+		}
+		optionsObj.NonceExpirationBlockHeight, err = strconv.ParseUint(nonceExpirationBlockHeightStr, 10, 64)
 		if err != nil {
-			return nil, wrapErr(ErrUnableToParseIntermediateResult, err)
+			return nil, wrapErr(ErrUnableToParseIntermediateResult, errors.Wrapf(err, "nonce_expiration_block_height: %v", nonceExpirationBlockHeightStr))
 		}
 	}
 	if nonceExpirationBlockBuffer, exists := request.Metadata["nonce_expiration_block_buffer"]; exists {
-		optionsObj.NonceExpirationBlockBuffer, err = strconv.ParseUint(nonceExpirationBlockBuffer.(string), 10, 64)
+		nonceExpirationBlockBufferStr, ok := nonceExpirationBlockBuffer.(string)
+		if !ok {
+			return nil, wrapErr(ErrUnableToParseIntermediateResult, fmt.Errorf("nonce_expiration_block_buffer is not a string"))
+		}
+		optionsObj.NonceExpirationBlockBuffer, err = strconv.ParseUint(nonceExpirationBlockBufferStr, 10, 64)
 		if err != nil {
-			return nil, wrapErr(ErrUnableToParseIntermediateResult, err)
+			return nil, wrapErr(ErrUnableToParseIntermediateResult, errors.Wrapf(err, "nonce_expiration_block_buffer: %v", nonceExpirationBlockBufferStr))
 		}
 	}
 	if feeRateNanosPerKB, exists := request.Metadata["fee_rate_nanos_per_kb"]; exists {
-		optionsObj.FeeRateNanosPerKB, err = strconv.ParseUint(feeRateNanosPerKB.(string), 10, 64)
+		feeRateNanosPerKBStr, ok := feeRateNanosPerKB.(string)
+		if !ok {
+			return nil, wrapErr(ErrUnableToParseIntermediateResult, fmt.Errorf("fee_rate_nanos_per_kb is not a string"))
+		}
+		optionsObj.FeeRateNanosPerKB, err = strconv.ParseUint(feeRateNanosPerKBStr, 10, 64)
 		if err != nil {
-			return nil, wrapErr(ErrUnableToParseIntermediateResult, err)
+			return nil, wrapErr(ErrUnableToParseIntermediateResult, errors.Wrapf(err, "fee_rate_nanos_per_kb: %v", feeRateNanosPerKBStr))
 		}
 	}
 	if txnFeeNanos, exists := request.Metadata["txn_fee_nanos"]; exists {
-		optionsObj.TxnFeeNanos, err = strconv.ParseUint(txnFeeNanos.(string), 10, 64)
+		txnFeeNanosStr, ok := txnFeeNanos.(string)
+		if !ok {
+			return nil, wrapErr(ErrUnableToParseIntermediateResult, fmt.Errorf("txn_fee_nanos is not a string"))
+		}
+		optionsObj.TxnFeeNanos, err = strconv.ParseUint(txnFeeNanosStr, 10, 64)
 		if err != nil {
-			return nil, wrapErr(ErrUnableToParseIntermediateResult, err)
+			return nil, wrapErr(ErrUnableToParseIntermediateResult, errors.Wrapf(err, "txn_fee_nanos: %v", txnFeeNanosStr))
 		}
 	}
 

--- a/services/errors.go
+++ b/services/errors.go
@@ -105,6 +105,11 @@ var (
 		Code:    16,
 		Message: "Nonce expiration block height is too high",
 	}
+
+	ErrLegacyUtxoSelectionNotAllowed = &types.Error{
+		Code:    17,
+		Message: "Legacy UTXO selection is not allowed after the migration to balance model",
+	}
 )
 
 // wrapErr adds details to the types.Error provided. We use a function

--- a/services/errors.go
+++ b/services/errors.go
@@ -91,9 +91,9 @@ var (
 		Message: "Fee specified is too low",
 	}
 
-	ErrNonceExpirationBlockBufferTooLarge = &types.Error{
+	ErrNonceExpirationBlockHeightOffsetTooLarge = &types.Error{
 		Code:    14,
-		Message: "Nonce expiration block buffer is too large",
+		Message: "Nonce expiration block height offset is too large",
 	}
 
 	ErrNonceExpirationBlockHeightTooLow = &types.Error{

--- a/services/errors.go
+++ b/services/errors.go
@@ -80,6 +80,31 @@ var (
 		Code:    11,
 		Message: "A transaction can only have one input",
 	}
+
+	ErrFeeRateBelowNetworkMinimum = &types.Error{
+		Code:    12,
+		Message: "Fee rate specified is below network minimum",
+	}
+
+	ErrFeeTooLow = &types.Error{
+		Code:    13,
+		Message: "Fee specified is too low",
+	}
+
+	ErrNonceExpirationBlockBufferTooLarge = &types.Error{
+		Code:    14,
+		Message: "Nonce expiration block buffer is too large",
+	}
+
+	ErrNonceExpirationBlockHeightTooLow = &types.Error{
+		Code:    15,
+		Message: "Nonce expiration block height is too low",
+	}
+
+	ErrNonceExpirationBlockHeightTooHigh = &types.Error{
+		Code:    16,
+		Message: "Nonce expiration block height is too high",
+	}
 )
 
 // wrapErr adds details to the types.Error provided. We use a function

--- a/services/types.go
+++ b/services/types.go
@@ -12,6 +12,20 @@ type preprocessOptions struct {
 	// Allow legacy manual selection of UTXOs
 	LegacyUTXOSelection bool         `json:"legacy_utxo_selection"` // Deprecated
 	DeSoInputs          []*desoInput `json:"deso_inputs"`           // Deprecated
+
+	// Values used to set TxnNonce. Note that only one of
+	// NonceExpirationBlockHeight and NonceExpirationBlockBuffer
+	// should be specified. If both are specified,
+	// NonceExpirationBlockBuffer is used.
+	NoncePartialID             uint64 `json:"nonce_partial_id"`
+	NonceExpirationBlockHeight uint64 `json:"nonce_expiration_block_height"`
+	NonceExpirationBlockBuffer uint64 `json:"nonce_expiration_block_buffer"`
+
+	// Values used to specify the fee for a transaction. Note that
+	// only one of FeeRateNanosPerKB and TxnFeeNanos should be specified.
+	// If both are specified, FeeRateNanosPerKB is used.
+	FeeRateNanosPerKB uint64 `json:"fee_rate_nanos_per_kb"`
+	TxnFeeNanos       uint64 `json:"txn_fee_nanos"`
 }
 
 type desoOutput struct {
@@ -36,6 +50,20 @@ type constructionMetadata struct {
 
 	// Allow legacy manual selection of UTXOs
 	LegacyUTXOSelection bool `json:"legacy_utxo_selection"` // Deprecated
+
+	// Values used to set TxnNonce. Note that only one of
+	// NonceExpirationBlockHeight and NonceExpirationBlockBuffer
+	// should be specified. If both are specified,
+	// NonceExpirationBlockBuffer is used.
+	NoncePartialID             uint64 `json:"nonce_partial_id"`
+	NonceExpirationBlockHeight uint64 `json:"nonce_expiration_block_height"`
+	NonceExpirationBlockBuffer uint64 `json:"nonce_expiration_block_buffer"`
+
+	// Values used to specify the fee for a transaction. Note that
+	// only one of FeeRateNanosPerKB and TxnFeeNanos should be specified.
+	// If both are specified, FeeRateNanosPerKB is used.
+	FeeRateNanosPerKB uint64 `json:"fee_rate_nanos_per_kb"`
+	TxnFeeNanos       uint64 `json:"txn_fee_nanos"`
 }
 
 type transactionMetadata struct {
@@ -44,6 +72,20 @@ type transactionMetadata struct {
 
 	// Allow legacy manual selection of UTXOs
 	LegacyUTXOSelection bool `json:"legacy_utxo_selection"` // Deprecated
+
+	// Values used to set TxnNonce. Note that only one of
+	// NonceExpirationBlockHeight and NonceExpirationBlockBuffer
+	// should be specified. If both are specified,
+	// NonceExpirationBlockBuffer is used.
+	NoncePartialID             uint64 `json:"nonce_partial_id"`
+	NonceExpirationBlockHeight uint64 `json:"nonce_expiration_block_height"`
+	NonceExpirationBlockBuffer uint64 `json:"nonce_expiration_block_buffer"`
+
+	// Values used to specify the fee for a transaction. Note that
+	// only one of FeeRateNanosPerKB and TxnFeeNanos should be specified.
+	// If both are specified, FeeRateNanosPerKB is used.
+	FeeRateNanosPerKB uint64 `json:"fee_rate_nanos_per_kb"`
+	TxnFeeNanos       uint64 `json:"txn_fee_nanos"`
 }
 
 type amountMetadata struct {

--- a/services/types.go
+++ b/services/types.go
@@ -14,12 +14,12 @@ type preprocessOptions struct {
 	DeSoInputs          []*desoInput `json:"deso_inputs"`           // Deprecated
 
 	// Values used to set TxnNonce. Note that only one of
-	// NonceExpirationBlockHeight and NonceExpirationBlockBuffer
+	// NonceExpirationBlockHeight and NonceExpirationBlockHeightOffset
 	// should be specified. If both are specified,
-	// NonceExpirationBlockBuffer is used.
-	NoncePartialID             uint64 `json:"nonce_partial_id"`
-	NonceExpirationBlockHeight uint64 `json:"nonce_expiration_block_height"`
-	NonceExpirationBlockBuffer uint64 `json:"nonce_expiration_block_buffer"`
+	// NonceExpirationBlockHeightOffset is used.
+	NoncePartialID                   uint64 `json:"nonce_partial_id"`
+	NonceExpirationBlockHeight       uint64 `json:"nonce_expiration_block_height"`
+	NonceExpirationBlockHeightOffset uint64 `json:"nonce_expiration_block_height_offset"`
 
 	// Values used to specify the fee for a transaction. Note that
 	// only one of FeeRateNanosPerKB and TxnFeeNanos should be specified.
@@ -52,12 +52,12 @@ type constructionMetadata struct {
 	LegacyUTXOSelection bool `json:"legacy_utxo_selection"` // Deprecated
 
 	// Values used to set TxnNonce. Note that only one of
-	// NonceExpirationBlockHeight and NonceExpirationBlockBuffer
+	// NonceExpirationBlockHeight and NonceExpirationBlockHeightOffset
 	// should be specified. If both are specified,
-	// NonceExpirationBlockBuffer is used.
-	NoncePartialID             uint64 `json:"nonce_partial_id"`
-	NonceExpirationBlockHeight uint64 `json:"nonce_expiration_block_height"`
-	NonceExpirationBlockBuffer uint64 `json:"nonce_expiration_block_buffer"`
+	// NonceExpirationBlockHeightOffset is used.
+	NoncePartialID                   uint64 `json:"nonce_partial_id"`
+	NonceExpirationBlockHeight       uint64 `json:"nonce_expiration_block_height"`
+	NonceExpirationBlockHeightOffset uint64 `json:"nonce_expiration_block_height_offset"`
 
 	// Values used to specify the fee for a transaction. Note that
 	// only one of FeeRateNanosPerKB and TxnFeeNanos should be specified.
@@ -74,12 +74,12 @@ type transactionMetadata struct {
 	LegacyUTXOSelection bool `json:"legacy_utxo_selection"` // Deprecated
 
 	// Values used to set TxnNonce. Note that only one of
-	// NonceExpirationBlockHeight and NonceExpirationBlockBuffer
+	// NonceExpirationBlockHeight and NonceExpirationBlockHeightOffset
 	// should be specified. If both are specified,
-	// NonceExpirationBlockBuffer is used.
-	NoncePartialID             uint64 `json:"nonce_partial_id"`
-	NonceExpirationBlockHeight uint64 `json:"nonce_expiration_block_height"`
-	NonceExpirationBlockBuffer uint64 `json:"nonce_expiration_block_buffer"`
+	// NonceExpirationBlockHeightOffset is used.
+	NoncePartialID                   uint64 `json:"nonce_partial_id"`
+	NonceExpirationBlockHeight       uint64 `json:"nonce_expiration_block_height"`
+	NonceExpirationBlockHeightOffset uint64 `json:"nonce_expiration_block_height_offset"`
 
 	// Values used to specify the fee for a transaction. Note that
 	// only one of FeeRateNanosPerKB and TxnFeeNanos should be specified.

--- a/services/types.go
+++ b/services/types.go
@@ -16,16 +16,30 @@ type preprocessOptions struct {
 	// Values used to set TxnNonce. Note that only one of
 	// NonceExpirationBlockHeight and NonceExpirationBlockHeightOffset
 	// should be specified. If both are specified,
+
 	// NonceExpirationBlockHeightOffset is used.
-	NoncePartialID                   uint64 `json:"nonce_partial_id"`
-	NonceExpirationBlockHeight       uint64 `json:"nonce_expiration_block_height"`
+	// NoncePartialID allows for specifying the partial ID used in the transaction's nonce.
+	NoncePartialID uint64 `json:"nonce_partial_id"`
+	// NonceExpirationBlockHeight allows for specifying the expiration block height used in
+	// the transaction's nonce. Must be greater than the current block height and less than
+	// the current block height plus the current network
+	NonceExpirationBlockHeight uint64 `json:"nonce_expiration_block_height"`
+	// NonceExpirationBlockHeightOffset allows for specifying the offset used to compute the
+	// expiration block height in the transaction's nonce. This takes priority over
+	// nonce_expiration_block_height. The expiration block height of the nonce will be set to
+	// the current block height plus this value. Must be less than the current network
+	// MaxNonceExpirationBlockHeightOffset value.
 	NonceExpirationBlockHeightOffset uint64 `json:"nonce_expiration_block_height_offset"`
 
 	// Values used to specify the fee for a transaction. Note that
 	// only one of FeeRateNanosPerKB and TxnFeeNanos should be specified.
-	// If both are specified, FeeRateNanosPerKB is used.
+
+	// FeeRateNanosPerKB allows for specifying a fee rate that differs from the network minimum.
+	// Must be greater than the network minimum.
 	FeeRateNanosPerKB uint64 `json:"fee_rate_nanos_per_kb"`
-	TxnFeeNanos       uint64 `json:"txn_fee_nanos"`
+	// TxnFeeNanos allows for explicitly specify the fee nanos field on a transaction.
+	// Must be greater than the fee nanos values computed when constructing the transaction.
+	TxnFeeNanos uint64 `json:"txn_fee_nanos"`
 }
 
 type desoOutput struct {


### PR DESCRIPTION
New options available:
1. `nonce_partial_id`: allows for specifying the partial ID used in the transaction's nonce.
2. `nonce_expiration_block_height`: allows for specifying the expiration block height used in the transaction's nonce. Must be greater than the current block height and less than the current block height plus the current network `MaxNonceExpirationBlockHeightOffset`.
3. `nonce_expiration_block_height_offset`: allows for specifying the offset used to compute the expiration block height in the transaction's nonce. This takes priority over `nonce_expiration_block_height`. The expiration block height of the nonce will be set to the current block height plus this value. Must be less than the current network `MaxNonceExpirationBlockHeightOffset` value.
4. `fee_rate_nanos_per_kb`: allows for specifying a fee rate that differs from the network minimum. Must be greater than the network minimum.
5. `txn_fee_nanos`: allows for explicitly specify the fee nanos field on a transaction. Must be greater than the fee nanos values computed when constructing the transaction.