### PR TITLE
Fix hypersync check:data

### DIFF
--- a/deso/block.go
+++ b/deso/block.go
@@ -53,17 +53,21 @@ func (node *Node) GetBlock(hash string) *types.Block {
 
 	// If we've hypersynced the chain, we do something special. We need to return "fake genesis" blocks that
 	// consolidates all balances up to this point. See commentary in events.go for more detail on how this works.
-	snapshot := node.Server.GetBlockchain().Snapshot()
-	if snapshot != nil && snapshot.CurrentEpochSnapshotMetadata.FirstSnapshotBlockHeight != 0 &&
-		height <= snapshot.CurrentEpochSnapshotMetadata.FirstSnapshotBlockHeight {
+	if node.Config.SyncType == lib.NodeSyncTypeHyperSync ||
+		node.Config.SyncType == lib.NodeSyncTypeHyperSyncArchival {
 
-		transactions := node.getBlockTransactionsWithHypersync(height, blockHash)
-		// We return a mega-fake-genesis block with the hypersync account balances bootstrapped via output operations.
-		return &types.Block{
-			BlockIdentifier:       blockIdentifier,
-			ParentBlockIdentifier: parentBlockIdentifier,
-			Timestamp:             int64(blockNode.Header.TstampNanoSecs) / 1e6, // Convert nanoseconds to milliseconds
-			Transactions:          transactions,
+		snapshot := node.Server.GetBlockchain().Snapshot()
+		if snapshot != nil && snapshot.CurrentEpochSnapshotMetadata.FirstSnapshotBlockHeight != 0 &&
+			height <= snapshot.CurrentEpochSnapshotMetadata.FirstSnapshotBlockHeight {
+
+			transactions := node.getBlockTransactionsWithHypersync(height, blockHash)
+			// We return a mega-fake-genesis block with the hypersync account balances bootstrapped via output operations.
+			return &types.Block{
+				BlockIdentifier:       blockIdentifier,
+				ParentBlockIdentifier: parentBlockIdentifier,
+				Timestamp:             int64(blockNode.Header.TstampNanoSecs) / 1e6, // Convert nanoseconds to milliseconds
+				Transactions:          transactions,
+			}
 		}
 	}
 

--- a/deso/events.go
+++ b/deso/events.go
@@ -466,7 +466,9 @@ func (node *Node) handleBlockCommitted(event *lib.BlockEvent) {
 	// We do some special logic if we have a snapshot.
 	if node.Server != nil {
 		snapshot := node.Server.GetBlockchain().Snapshot()
-		if snapshot != nil &&
+		if (node.Config.SyncType == lib.NodeSyncTypeHyperSync ||
+			node.Config.SyncType == lib.NodeSyncTypeHyperSyncArchival) &&
+			snapshot != nil &&
 			snapshot.CurrentEpochSnapshotMetadata.FirstSnapshotBlockHeight != 0 {
 
 			firstSnapshotHeight := snapshot.CurrentEpochSnapshotMetadata.FirstSnapshotBlockHeight


### PR DESCRIPTION
Running Rosetta with `--sync-type=blocksync` and `--hypersync=true` would cause Rosetta to think that we synced using a snapshot, rather than using a full block sync. This resulted in check:data failing because it was assuming we downloaded a single snapshot during sync. The fix is to add a check for the `--sync-type` being `hypersync` or `hypersync-archival` before doing the snapshotting logic.